### PR TITLE
Skaičiaus kintamojo nereikia vėl konvertuoti į skaičių

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,26 +1,20 @@
 let n1;
 n1 = 26;
-n1 = + n1;
 
 let d1;
 d1 = 2;
-d1 = + d1;
 
 let a1;
 a1 = 5;
-a1 = + a1;
 
 let n2;
 n2 = 37;
-n2 = + n2;
 
 let d2;
 d2 = -6;
-d2 = + d2;
 
 let a2;
 a2 = 17;
-a2 = + a2;
 
 let progresija1 = aritmetineProgresija(n1, d1, a1);
 console.log(progresija1);


### PR DESCRIPTION
Jeigu reikšmę prie kintamojo išsaugote be kabučių, tai tai nėra tekstas, todėl jo konvertuoti į skaičių nereikia. Kai naudojame `prompt`, tai konvertuojame, nes prompt() funkcija grąžina tekstinę reikšmę